### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/bendevopsdemo/54db1cc3-d68c-417d-bfee-ea93e95c8ea8/dafe231f-c843-4f85-9983-f7b3301900f4/_apis/work/boardbadge/3073ba86-d8f5-45b7-8181-9c6a212969cb)](https://dev.azure.com/bendevopsdemo/54db1cc3-d68c-417d-bfee-ea93e95c8ea8/_boards/board/t/dafe231f-c843-4f85-9983-f7b3301900f4/Microsoft.RequirementCategory)
 # aisdlcdemo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#575](https://dev.azure.com/bendevopsdemo/54db1cc3-d68c-417d-bfee-ea93e95c8ea8/_workitems/edit/575). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.